### PR TITLE
Added unit test for the Datalog Mapper.

### DIFF
--- a/EmbASP.csproj
+++ b/EmbASP.csproj
@@ -151,6 +151,7 @@
     <Compile Include="it\unical\mat\parsers\pddl\solver_planning_domains\SPDGrammarVisitor.cs" />
     <Compile Include="it\unical\mat\test\language\asp\Arity0.cs" />
     <Compile Include="it\unical\mat\test\language\asp\ASPMapperTest.cs" />
+    <Compile Include="it\unical\mat\test\language\datalog\DatalogMapperTest.cs" />
     <Compile Include="it\unical\mat\test\language\pddl\PDDLMapperTest.cs" />
     <Compile Include="it\unical\mat\test\specialization\clingo\ClingoDesktopServiceTest.cs" />
     <Compile Include="it\unical\mat\test\specialization\dlv2\DLV2DesktopServiceTest.cs" />

--- a/it/unical/mat/test/language/datalog/DatalogMapperTest.cs
+++ b/it/unical/mat/test/language/datalog/DatalogMapperTest.cs
@@ -1,0 +1,45 @@
+﻿using it.unical.mat.embasp.languages.datalog;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace it.unical.mat.test
+{
+    [TestClass()]
+    public class DatalogMapperTest
+    {
+        [TestMethod()]
+        public void Test()
+        {
+            DatalogMapper instance = DatalogMapper.Instance;
+
+            try
+            {
+                instance.RegisterClass(typeof(Cell));
+
+                Object @object = instance.GetObject("cell(1,2,5)");
+
+                Assert.IsTrue(@object is Cell);
+                Assert.AreEqual(1, ((Cell)@object).getRow());
+                Assert.AreEqual(2, ((Cell)@object).getColumn());
+                Assert.AreEqual(5, ((Cell)@object).getValue());
+                Assert.AreEqual("cell(1,2,5)", instance.GetString(@object));
+                instance.UnregisterClass(typeof(Cell));
+
+                object nullObject = instance.GetObject("cell(1,2,5)");
+
+                Assert.IsNull(nullObject);
+                instance.RegisterClass(typeof(Arity0));
+
+                object object1 = instance.GetObject("a");
+
+                Assert.IsNotNull(object1);
+                Assert.IsTrue(object1 is Arity0);
+                Assert.AreEqual("a", instance.GetString(object1));
+            }
+            catch (Exception e)
+            {
+                Assert.Fail(e.Message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Since every language supported by EmbASP must have its own unit test class, it was necessary to add a test class for Datalog as well, to keep the implementation of the language in line with the other implementations. It's a simple and short class, almost identical to the ASP test class.